### PR TITLE
#5 add name of the file in preview (need to do test)

### DIFF
--- a/cli-go/chapter-03/workingFiles/mdp/main_test.go
+++ b/cli-go/chapter-03/workingFiles/mdp/main_test.go
@@ -19,7 +19,7 @@ func TestParseContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := parseContent(input, "")
+	result, err := parseContent(input, "", "./testdata/test1.md.html")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,6 +36,7 @@ func TestParseContent(t *testing.T) {
 	}
 }
 
+// TODO: update file previewed result vs. golden
 func TestRun(t *testing.T) {
 	var mockStdOut bytes.Buffer
 

--- a/cli-go/chapter-03/workingFiles/mdp/testdata/test1.md.html
+++ b/cli-go/chapter-03/workingFiles/mdp/testdata/test1.md.html
@@ -5,6 +5,7 @@
         <title>Markdown Preview Tool</title>
     </head>
     <body>
+./testdata/test1.md.html
 <h1>Test Markdown File</h1>
 
 <p>Just a test</p>


### PR DESCRIPTION
Missing:
- Update the mdp tool allowing the user to specify a default template using an environment variable.
- Update the mdp tool allowing the user to provide the input Markdown via STDIN.
- tests for name of the file in preview.